### PR TITLE
Added Template, Campaign, and Campaign Messages stream - feature/hgi-10557

### DIFF
--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -235,12 +235,19 @@ class KlaviyoStream(RESTStream):
         # discover for child streams
         if self.parent_stream_type:
             parent_url = self.url_base + self.parent_stream_type.path
-            id = self.request_decorator(self.get_data)(request_type, parent_url, headers)
-            if id:
-                id = id[0]["id"]
-            url = url.replace("{id}", id)
-
-        records = self.request_decorator(self.get_data)(request_type, url, headers)
+            parent_records = self.request_decorator(self.get_data)(
+                request_type, parent_url, headers
+            )
+            parent_id = parent_records[0]["id"] if parent_records else None
+            if parent_id:
+                url = url.replace("{id}", parent_id)
+                records = self.request_decorator(self.get_data)(
+                    request_type, url, headers
+                )
+            else:
+                records = []
+        else:
+            records = self.request_decorator(self.get_data)(request_type, url, headers)
 
         if len(records) > 0:
             flattened_records = [self._flatten_discovery_record(record) for record in records]

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -121,6 +121,38 @@ class KlaviyoStream(RESTStream):
         except:
             return False
 
+    def _looks_like_datetime(self, value: Any) -> bool:
+        if not isinstance(value, str):
+            return False
+        try:
+            parse(value)
+            return True
+        except Exception:
+            return False
+
+    def _flatten_discovery_record(self, record: dict) -> dict:
+        record = dict(record)
+        attributes = record.pop("attributes", {})
+        if attributes:
+            record.update(attributes)
+        return record
+
+    def _first_non_null_value(self, records: list, field_name: str) -> Any:
+        for record in records:
+            value = record.get(field_name)
+            if value is not None:
+                return value
+        return None
+
+    def _infer_property_type(self, name: str, value: Any) -> th.Property:
+        if name in ["event_properties", "properties"]:
+            return th.Property(name, th.CustomType({"type": ["object", "string"]}))
+        if value is None:
+            return th.Property(name, th.StringType)
+        if self._looks_like_datetime(value):
+            return th.Property(name, th.DateTimeType)
+        return th.Property(name, self.get_jsonschema_type(value))
+
     def get_jsonschema_type(self, obj):
         dtype = type(obj)
 
@@ -211,32 +243,21 @@ class KlaviyoStream(RESTStream):
         records = self.request_decorator(self.get_data)(request_type, url, headers)
 
         if len(records) > 0:
-            properties = []
-            property_names = set()
+            flattened_records = [self._flatten_discovery_record(record) for record in records]
+            property_names: list[str] = []
+            seen: set[str] = set()
+            for record in flattened_records:
+                for name in record.keys():
+                    if name not in seen:
+                        seen.add(name)
+                        property_names.append(name)
 
-            record = records[0]
-            # put attributes fields at header level
-            attributes = record.pop("attributes", {})
-            if attributes:
-                record.update(attributes)
-
-            # Loop through each key in the object
-            for name in record.keys():
-                if name in property_names:
-                    continue
-                # Add the new property to our list
-                property_names.add(name)
-                if name in  ["event_properties", "properties"]:
-                    properties.append(
-                        th.Property(name, th.CustomType({"type": ["object", "string"]}))
-                    ) 
-                elif self.is_unix_timestamp(record[name]):
-                    properties.append(th.Property(name, th.DateTimeType))
-                else:
-                    properties.append(
-                        th.Property(name, self.get_jsonschema_type(record[name]))
-                    )
-            # Return the list as a JSON Schema dictionary object
+            properties = [
+                self._infer_property_type(
+                    name, self._first_non_null_value(flattened_records, name)
+                )
+                for name in property_names
+            ]
             property_list = th.PropertiesList(*properties).to_dict()
         else:
             property_list = th.PropertiesList(

--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -213,13 +213,11 @@ class CampaignMessagesStream(KlaviyoStream):
     def get_data(self, method: str, url: str, headers: dict) -> list:
         """Fetch parent campaign id for schema discovery with a channel filter."""
         if url.rstrip("/").endswith(self.parent_stream_type.path):
-            params = self.parent_stream_type.get_url_params(
-                self.parent_stream_type(tap=self._tap),
-                {"channel": self.parent_stream_type.channels[0]},
-                None,
-            )
-            if params:
-                url = f"{url}?{urlencode(params)}"
+            parent = self.parent_stream_type(tap=self._tap)
+            params = {
+                "filter": parent._channel_filter(self.parent_stream_type.channels[0])
+            }
+            url = f"{url}?{urlencode(params)}"
         return super().get_data(method, url, headers)
 
     def get_schema(self) -> dict:

--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -125,6 +125,16 @@ class CampaignsStream(KlaviyoStream):
     replication_key = "updated_at"
     channels = ("email", "sms")
 
+    @property
+    def state_partitioning_keys(self) -> Optional[List[str]]:
+        """Keep independent bookmarks per channel."""
+        return ["channel"]
+
+    @property
+    def partitions(self) -> Optional[List[dict]]:
+        """Sync each channel separately so bookmarks do not bleed across channels."""
+        return [{"channel": channel} for channel in self.channels]
+
     def _channel_filter(self, channel: str) -> str:
         return f"equals(messages.channel,'{channel}')"
 
@@ -174,13 +184,6 @@ class CampaignsStream(KlaviyoStream):
         if context and context.get("channel"):
             child_context["channel"] = context["channel"]
         return child_context
-
-    def get_records(self, context: Optional[dict]):
-        """Fetch campaigns for each supported channel."""
-        context = context or {}
-        for channel in self.channels:
-            channel_context = {**context, "channel": channel}
-            yield from super().get_records(channel_context)
 
     def post_process(self, row, context):
         row = super().post_process(row, context)

--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -168,9 +168,8 @@ class CampaignsStream(KlaviyoStream):
 
     def get_data(self, method: str, url: str, headers: dict) -> list:
         """Fetch sample records for schema discovery with a channel filter."""
-        params = self.get_url_params({"channel": self.channels[0]}, None)
-        if params:
-            url = f"{url}?{urlencode(params)}"
+        params = {"filter": self._channel_filter(self.channels[0])}
+        url = f"{url}?{urlencode(params)}"
         return super().get_data(method, url, headers)
 
     def get_schema(self) -> dict:

--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -1,6 +1,7 @@
 """Stream type classes for tap-klaviyo."""
 
 from typing import Any, Dict, Optional, List
+from urllib.parse import urlencode
 from tap_klaviyo.client import KlaviyoStream
 from hotglue_singer_sdk import typing as th
 from datetime import datetime, timedelta, timezone
@@ -113,6 +114,138 @@ class ListMembersStream(KlaviyoStream):
     primary_keys = ["id"]
     replication_key = "joined_group_at"
     parent_stream_type = ListsStream
+
+
+class CampaignsStream(KlaviyoStream):
+    """Klaviyo campaigns stream."""
+
+    name = "campaigns"
+    path = "/campaigns"
+    primary_keys = ["id"]
+    replication_key = "updated_at"
+    channels = ("email", "sms")
+
+    def _channel_filter(self, channel: str) -> str:
+        return f"equals(messages.channel,'{channel}')"
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return URL params with the required channel filter."""
+        params: dict = {}
+        if next_page_token:
+            params["page[cursor]"] = next_page_token
+
+        channel = (context or {}).get("channel", self.channels[0])
+        channel_filter = self._channel_filter(channel)
+        start_date = self.get_starting_time(context)
+        if self.replication_key and start_date:
+            start_date = start_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+            if self.config.get("end_date"):
+                end_date = parse(self.config.get("end_date"))
+                end_date = end_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+                params["filter"] = (
+                    f"and({channel_filter},greater-than({self.replication_key},{start_date}),"
+                    f"less-or-equal({self.replication_key},{end_date}))"
+                )
+            else:
+                params["filter"] = (
+                    f"and({channel_filter},greater-than({self.replication_key},{start_date}))"
+                )
+        else:
+            params["filter"] = channel_filter
+        return params
+
+    def get_data(self, method: str, url: str, headers: dict) -> list:
+        """Fetch sample records for schema discovery with a channel filter."""
+        params = self.get_url_params({"channel": self.channels[0]}, None)
+        if params:
+            url = f"{url}?{urlencode(params)}"
+        return super().get_data(method, url, headers)
+
+    def get_schema(self) -> dict:
+        schema = super().get_schema()
+        schema.setdefault("properties", {})
+        schema["properties"].update(th.Property("channel", th.StringType).to_dict())
+        return schema
+
+    def get_child_context(self, record, context):
+        child_context = {"id": record["id"]}
+        if context and context.get("channel"):
+            child_context["channel"] = context["channel"]
+        return child_context
+
+    def get_records(self, context: Optional[dict]):
+        """Fetch campaigns for each supported channel."""
+        context = context or {}
+        for channel in self.channels:
+            channel_context = {**context, "channel": channel}
+            yield from super().get_records(channel_context)
+
+    def post_process(self, row, context):
+        row = super().post_process(row, context)
+        if context and context.get("channel"):
+            row["channel"] = context["channel"]
+        return row
+
+
+class CampaignMessagesStream(KlaviyoStream):
+    """Campaign message details for each campaign (child of campaigns)."""
+
+    name = "campaign_messages"
+    path = "/campaigns/{id}/campaign-messages"
+    primary_keys = ["id"]
+    replication_key = None
+    parent_stream_type = CampaignsStream
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return URL params; nested endpoint does not support date filters."""
+        params: dict = {}
+        if next_page_token:
+            params["page[cursor]"] = next_page_token
+        return params
+
+    def get_data(self, method: str, url: str, headers: dict) -> list:
+        """Fetch parent campaign id for schema discovery with a channel filter."""
+        if url.rstrip("/").endswith(self.parent_stream_type.path):
+            params = self.parent_stream_type.get_url_params(
+                self.parent_stream_type(tap=self._tap),
+                {"channel": self.parent_stream_type.channels[0]},
+                None,
+            )
+            if params:
+                url = f"{url}?{urlencode(params)}"
+        return super().get_data(method, url, headers)
+
+    def get_schema(self) -> dict:
+        schema = super().get_schema()
+        schema.setdefault("properties", {})
+        schema["properties"].update(th.Property("campaign_id", th.StringType).to_dict())
+        schema["properties"].update(th.Property("template_id", th.StringType).to_dict())
+        return schema
+
+    def post_process(self, row, context):
+        row = super().post_process(row, context)
+        if context and context.get("id"):
+            row["campaign_id"] = context["id"]
+        template = (row.get("relationships") or {}).get("template", {}).get("data")
+        if template and template.get("id"):
+            row["template_id"] = template["id"]
+        return row
+
+
+class TemplatesStream(KlaviyoStream):
+    """Standalone incremental stream for Klaviyo templates.
+
+    Join to campaigns via campaign_messages.template_id -> templates.id.
+    """
+
+    name = "templates"
+    path = "/templates"
+    primary_keys = ["id"]
+    replication_key = "updated"
 
 
 class ReviewsStream(KlaviyoStream):

--- a/tap_klaviyo/tap.py
+++ b/tap_klaviyo/tap.py
@@ -11,6 +11,8 @@ from tap_klaviyo.exceptions import MissingPermissionsError
 
 
 from tap_klaviyo.streams import (
+    CampaignMessagesStream,
+    CampaignsStream,
     ContactsStream,
     EventsStream,
     ListMembersStream,
@@ -18,6 +20,7 @@ from tap_klaviyo.streams import (
     MetricsStream,
     ReviewsStream,
     ReportStream,
+    TemplatesStream,
 )
 
 STREAM_TYPES = [
@@ -27,6 +30,9 @@ STREAM_TYPES = [
     EventsStream,
     ListMembersStream,
     ReviewsStream,
+    CampaignsStream,
+    CampaignMessagesStream,
+    TemplatesStream,
 ]
 
 


### PR DESCRIPTION
This PR implements 3 new streams:

1. Templates via the [GET templates endpoint](https://developers.klaviyo.com/en/reference/get_template)
2. Campaigns via the [GET campaigns endpoint](https://developers.klaviyo.com/en/reference/get_campaigns)
3. CampaignMessages [GET campaign messages endpoint](https://developers.klaviyo.com/en/reference/get_messages_for_campaign)

Campaigns are a parent stream to the child stream CampaignMessages - which is joined by the child context 
`child_context = {"id": record["id"]} `

Templates are joined to each CampaignMessage via a `template_id` field. 

Both the Campaign and Template stream support incremental sync - with separate replication keys for both streams. 

Additional functionality was added to the `client.py` class because some of the new streams can have NULL data (i.e., you didn't set a send time for a campaign). The auto schema discovery function couldn't handle this before - so now we scan for non null records first to infer schemas. 

Discover, Sync, and Target-Parquet were validated locally. I also validated the data using `hotglue singer validate:`
<img width="596" height="213" alt="image" src="https://github.com/user-attachments/assets/365089c0-5464-4e18-9189-7bd010bdc2c5" />
